### PR TITLE
Fix initilizations

### DIFF
--- a/src/transformers/modeling_tf_outputs.py
+++ b/src/transformers/modeling_tf_outputs.py
@@ -110,8 +110,8 @@ class TFBaseModelOutputWithPoolingAndNoAttention(ModelOutput):
         pooler_output (`tf.Tensor` of shape `(batch_size, hidden_size)`):
             Last layer hidden-state after a pooling operation on the spatial dimensions.
         hidden_states (`tuple(tf.Tensor)`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
-            Tuple of `tf.Tensor` (one for the output of the embeddings, if the model has an embedding layer, +
-            one for the output of each layer) of shape `(batch_size, num_channels, height, width)`.
+            Tuple of `tf.Tensor` (one for the output of the embeddings, if the model has an embedding layer, + one for
+            the output of each layer) of shape `(batch_size, num_channels, height, width)`.
 
             Hidden-states of the model at the output of each layer plus the optional initial embedding outputs.
     """
@@ -830,6 +830,7 @@ class TFSequenceClassifierOutputWithPast(ModelOutput):
     hidden_states: Optional[Tuple[tf.Tensor]] = None
     attentions: Optional[Tuple[tf.Tensor]] = None
 
+
 @dataclass
 class TFImageClassifierOutputWithNoAttention(ModelOutput):
     """
@@ -841,9 +842,9 @@ class TFImageClassifierOutputWithNoAttention(ModelOutput):
         logits (`tf.Tensor` of shape `(batch_size, config.num_labels)`):
             Classification (or regression if config.num_labels==1) scores (before SoftMax).
         hidden_states (`tuple(tf.Tensor)`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
-            Tuple of `tf.Tensor` (one for the output of the embeddings, if the model has an embedding layer, +
-            one for the output of each stage) of shape `(batch_size, num_channels, height, width)`. Hidden-states (also
-            called feature maps) of the model at the output of each stage.
+            Tuple of `tf.Tensor` (one for the output of the embeddings, if the model has an embedding layer, + one for
+            the output of each stage) of shape `(batch_size, num_channels, height, width)`. Hidden-states (also called
+            feature maps) of the model at the output of each stage.
     """
 
     loss: Optional[tf.Tensor] = None

--- a/src/transformers/models/regnet/configuration_regnet.py
+++ b/src/transformers/models/regnet/configuration_regnet.py
@@ -36,6 +36,8 @@ class RegNetConfig(PretrainedConfig):
     documentation from [`PretrainedConfig`] for more information.
 
     Args:
+        image_size (`int`, *optional*, defaults to 224):
+            Size of the input images.
         num_channels (`int`, *optional*, defaults to 3):
             The number of input channels.
         embedding_size (`int`, *optional*, defaults to 64):
@@ -71,6 +73,7 @@ class RegNetConfig(PretrainedConfig):
 
     def __init__(
         self,
+        image_size=224,
         num_channels=3,
         embedding_size=32,
         hidden_sizes=[128, 192, 512, 1088],
@@ -83,6 +86,7 @@ class RegNetConfig(PretrainedConfig):
         super().__init__(**kwargs)
         if layer_type not in self.layer_types:
             raise ValueError(f"layer_type={layer_type} is not one of {','.join(self.layer_types)}")
+        self.image_size = image_size
         self.num_channels = num_channels
         self.embedding_size = embedding_size
         self.hidden_sizes = hidden_sizes


### PR DESCRIPTION
There were a couple of inconsistencies that needed to be taken care of. The PR introduces changes to fix those. 

This is how the progression of feature map sizes should look like for the test model in PyTorch:

```py
***********RegNetYLayer***********
Hidden states: torch.Size([1, 128, 56, 56])
Residual: torch.Size([1, 128, 56, 56])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 128, 56, 56])
Residual: torch.Size([1, 128, 56, 56])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 192, 28, 28])
Residual: torch.Size([1, 192, 28, 28])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 192, 28, 28])
Residual: torch.Size([1, 192, 28, 28])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 192, 28, 28])
Residual: torch.Size([1, 192, 28, 28])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 192, 28, 28])
Residual: torch.Size([1, 192, 28, 28])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 192, 28, 28])
Residual: torch.Size([1, 192, 28, 28])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 192, 28, 28])
Residual: torch.Size([1, 192, 28, 28])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 512, 14, 14])
Residual: torch.Size([1, 512, 14, 14])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 512, 14, 14])
Residual: torch.Size([1, 512, 14, 14])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 512, 14, 14])
Residual: torch.Size([1, 512, 14, 14])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 512, 14, 14])
Residual: torch.Size([1, 512, 14, 14])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 512, 14, 14])
Residual: torch.Size([1, 512, 14, 14])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 512, 14, 14])
Residual: torch.Size([1, 512, 14, 14])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 512, 14, 14])
Residual: torch.Size([1, 512, 14, 14])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 512, 14, 14])
Residual: torch.Size([1, 512, 14, 14])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 512, 14, 14])
Residual: torch.Size([1, 512, 14, 14])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 512, 14, 14])
Residual: torch.Size([1, 512, 14, 14])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 512, 14, 14])
Residual: torch.Size([1, 512, 14, 14])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 512, 14, 14])
Residual: torch.Size([1, 512, 14, 14])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 1088, 7, 7])
Residual: torch.Size([1, 1088, 7, 7])
***********RegNetYLayer***********
Hidden states: torch.Size([1, 1088, 7, 7])
Residual: torch.Size([1, 1088, 7, 7])
```

Print statements were placed in the Y block's forward() method. 

Currently, we are getting when running the TF integration test (playground):

```
Traceback (most recent call last):
  File "playground_tf_regnet.py", line 14, in <module>
    model = TFRegNetForImageClassification.from_pretrained("facebook/regnet-y-040", from_pt=True)
  File "/Users/sayakpaul/Downloads/Misc/transformers/src/transformers/modeling_tf_utils.py", line 1878, in from_pretrained
    return load_pytorch_checkpoint_in_tf2_model(model, resolved_archive_file, allow_missing_keys=True)
  File "/Users/sayakpaul/Downloads/Misc/transformers/src/transformers/modeling_tf_pytorch_utils.py", line 124, in load_pytorch_checkpoint_in_tf2_model
    return load_pytorch_weights_in_tf2_model(
  File "/Users/sayakpaul/Downloads/Misc/transformers/src/transformers/modeling_tf_pytorch_utils.py", line 155, in load_pytorch_weights_in_tf2_model
    tf_model(tf_inputs, training=False)  # Make sure model is built
  File "/Users/sayakpaul/.local/bin/.virtualenvs/hf/lib/python3.8/site-packages/keras/utils/traceback_utils.py", line 67, in error_handler
    raise e.with_traceback(filtered_tb) from None
  File "/Users/sayakpaul/Downloads/Misc/transformers/src/transformers/modeling_tf_utils.py", line 383, in run_call_with_unpacked_inputs
    return func(self, **unpacked_inputs)
  File "/Users/sayakpaul/Downloads/Misc/transformers/src/transformers/models/regnet/modeling_tf_regnet.py", line 566, in call
    outputs = self.regnet(pixel_values, output_hidden_states=output_hidden_states, return_dict=return_dict)
  File "/Users/sayakpaul/Downloads/Misc/transformers/src/transformers/models/regnet/modeling_tf_regnet.py", line 373, in call
    encoder_outputs = self.encoder(
  File "/Users/sayakpaul/Downloads/Misc/transformers/src/transformers/models/regnet/modeling_tf_regnet.py", line 336, in call
    hidden_state = stage_module(hidden_state)
  File "/Users/sayakpaul/Downloads/Misc/transformers/src/transformers/models/regnet/modeling_tf_regnet.py", line 304, in call
    hidden_state = layer_module(hidden_state)
  File "/Users/sayakpaul/Downloads/Misc/transformers/src/transformers/models/regnet/modeling_tf_regnet.py", line 280, in call
    hidden_state += residual
tensorflow.python.framework.errors_impl.InvalidArgumentError: Exception encountered when calling layer "layer.0" (type TFRegNetYLayer).

Incompatible shapes: [3,55,55,128] vs. [3,111,111,32] [Op:AddV2]

Call arguments received:
  • hidden_state=tf.Tensor(shape=(3, 111, 111, 32), dtype=float32)
```

We need to fix this part. 